### PR TITLE
defer loading of javascript resource's.

### DIFF
--- a/www/layout.erb
+++ b/www/layout.erb
@@ -9,10 +9,14 @@
     <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/styles/default.min.css">
     <link rel="stylesheet" href="css/roda.css">
-    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/highlight.min.js"></script>
-    <script>hljs.initHighlightingOnLoad();</script>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js" defer></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" defer></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/highlight.min.js" defer></script>
+    <script>
+      document.addEventListener("load", function() {
+        hljs.initHighlightingOnLoad();
+      });
+    </script>
   </head>
   <body>
     <nav class="navbar navbar-default navigation-clean">


### PR DESCRIPTION
the "defer" attribute can be used to delay the loading of javascript resources
until the document has been parsed, which avoids blocking the rendering process
of the browser. see "defer" attribute at 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script for more details.

we also use the 'load' event before running any Javascript, so we know at that point
external JS resources have been loaded. please test this locally, as i wasn't able to.
i'm happy to revise if there's any issues. cheers.